### PR TITLE
Fix iOS handling for unknown calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A flutter plugin provides the best way to exit the app doesn't call `exit(0)` in
 add plugin to your `pubspec.yaml`
 
 ```yaml
-flutter_exit_app: release
+flutter_exit_app: ^1.1.4
 ```
 
 ## Usage

--- a/android/src/main/java/com/laoitdev/lib/exit/app/flutter_exit_app/ChannelName.java
+++ b/android/src/main/java/com/laoitdev/lib/exit/app/flutter_exit_app/ChannelName.java
@@ -1,5 +1,5 @@
 package com.laoitdev.lib.exit.app.flutter_exit_app;
 
 public class ChannelName {
-    public static final String exitapp = "com.laoitdev.exit.app";
+    public static final String exitApp = "com.laoitdev.exit.app";
 }

--- a/android/src/main/java/com/laoitdev/lib/exit/app/flutter_exit_app/FlutterExitAppPlugin.java
+++ b/android/src/main/java/com/laoitdev/lib/exit/app/flutter_exit_app/FlutterExitAppPlugin.java
@@ -34,7 +34,7 @@ public class FlutterExitAppPlugin implements FlutterPlugin, MethodCallHandler, A
       case "getPlatformVersion":
         result.success("Android " + Build.VERSION.RELEASE);
         break;
-      case ChannelName.exitapp:
+      case ChannelName.exitApp:
         handleExitApp(result);
         break;
       default:

--- a/ios/Classes/SwiftFlutterExitAppPlugin.swift
+++ b/ios/Classes/SwiftFlutterExitAppPlugin.swift
@@ -1,6 +1,10 @@
 import Flutter
 import UIKit
 
+enum ChannelName {
+    static let exitApp = "com.laoitdev.exit.app"
+}
+
 public class SwiftFlutterExitAppPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_exit_app", binaryMessenger: registrar.messenger())
@@ -12,13 +16,13 @@ public class SwiftFlutterExitAppPlugin: NSObject, FlutterPlugin {
       
       if call.method == "getPlatformVersion" {
             result("iOS " + UIDevice.current.systemVersion)
-      } else if call.method == "com.laoitdev.exit.app" {
+      } else if call.method == ChannelName.exitApp {
             let passData = parseArg(call)
           quit(killIosProcess: passData.killIosProcess)
             result("Done")
-      }else {
-            result("NOT_IMPLEMENT")
-    }
+      } else {
+            result(FlutterMethodNotImplemented)
+      }
 
   }
     


### PR DESCRIPTION
## Summary
- return `FlutterMethodNotImplemented` when an iOS call is unknown
- use a consistent `exitApp` constant name for Android and iOS
- fix install instructions in `README.md`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*